### PR TITLE
fix: remove sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ curl -sSL https://raw.githubusercontent.com/sadiksaifi/mac-menu/main/install.sh 
 2. Build and install:
    ```bash
    make
-   sudo make install
+   make install
    ```
 
 To uninstall:
 
 ```bash
-sudo make uninstall
+make uninstall
 ```
 
 ## Usage


### PR DESCRIPTION
It seems fine to run the installer without using `sudo`. As a security measure its best to not use `sudo` if not needed.