### PR TITLE
fix: handle empty stdin gracefully  (fixes #2)

### DIFF
--- a/src/main.swift
+++ b/src/main.swift
@@ -8,6 +8,7 @@
  */
 
 import Cocoa
+import Darwin
 
 /// A custom table row view that provides hover and selection effects
 class HoverTableRowView: NSTableRowView {
@@ -351,11 +352,30 @@ class MenuApp: NSObject, NSApplicationDelegate, NSTableViewDataSource, NSTableVi
     
     /// Loads input from stdin and populates the items list
     func loadInput() {
+        // Check if stdin is a terminal
+        if isatty(FileHandle.standardInput.fileDescriptor) != 0 {
+            print("Error: No input provided. Please pipe some input into mac-menu.")
+            print("Use 'mac-menu --help' to learn more about how to use the program.")
+            NSApp.terminate(nil)
+            return
+        }
+        
+        // Try to read available input
         if let input = try? String(data: FileHandle.standardInput.readToEnd() ?? Data(), encoding: .utf8) {
+            if input.isEmpty {
+                print("Error: No input provided. Please pipe some input into mac-menu.")
+                print("Use 'mac-menu --help' to learn more about how to use the program.")
+                NSApp.terminate(nil)
+                return
+            }
             allItems = input.components(separatedBy: .newlines).filter { !$0.isEmpty }
             filteredItems = allItems
             tableView.reloadData()
             selectRow(index: 0)
+        } else {
+            print("Error: No input provided. Please pipe some input into mac-menu.")
+            print("Use 'mac-menu --help' to learn more about how to use the program.")
+            NSApp.terminate(nil)
         }
     }
     


### PR DESCRIPTION
- Add check for terminal input using isatty
- Show helpful error message when no input is provided
- Exit immediately instead of hanging when no input is available

This fixes the issue where the program would hang indefinitely when run without piped input. Now it properly detects when no input is provided and shows a helpful error message guiding users to use the help flag.