### PR TITLE
feat: implement fzf-style fuzzy search algorithm

### DIFF
--- a/src/main.swift
+++ b/src/main.swift
@@ -74,6 +74,104 @@ class MenuApp: NSObject, NSApplicationDelegate, NSTableViewDataSource, NSTableVi
     /// Items filtered by search query
     var filteredItems: [String] = []
     
+    /// Fuzzy search result containing the matched string and its score
+    private struct FuzzyMatchResult {
+        let string: String
+        let score: Int
+        let positions: [Int]
+    }
+    
+    /// Constants for scoring
+    private struct ScoreConfig {
+        static let bonusMatch: Int = 16
+        static let bonusBoundary: Int = 16
+        static let bonusConsecutive: Int = 16
+        static let penaltyGapStart: Int = -3
+        static let penaltyGapExtension: Int = -1
+        static let penaltyNonContiguous: Int = -5
+    }
+    
+    /// Fuzzy search function implementing fzf's algorithm
+    /// - Parameters:
+    ///   - pattern: The search pattern to match
+    ///   - string: The string to search in
+    /// - Returns: A tuple containing whether there's a match and the match result
+    private func fuzzyMatch(pattern: String, string: String) -> (Bool, FuzzyMatchResult?) {
+        let pattern = pattern.lowercased()
+        let string = string.lowercased()
+        
+        // Empty pattern matches everything
+        if pattern.isEmpty {
+            return (true, FuzzyMatchResult(string: string, score: 0, positions: []))
+        }
+        
+        let patternLength = pattern.count
+        let stringLength = string.count
+        
+        // If pattern is longer than string, no match possible
+        if patternLength > stringLength {
+            return (false, nil)
+        }
+        
+        // Initialize score matrix
+        var scores = Array(repeating: Array(repeating: 0, count: stringLength + 1), count: patternLength + 1)
+        var positions = Array(repeating: Array(repeating: [Int](), count: stringLength + 1), count: patternLength + 1)
+        
+        // Fill score matrix
+        for i in 1...patternLength {
+            for j in 1...stringLength {
+                let patternChar = pattern[pattern.index(pattern.startIndex, offsetBy: i - 1)]
+                let stringChar = string[string.index(string.startIndex, offsetBy: j - 1)]
+                
+                if patternChar == stringChar {
+                    var score = ScoreConfig.bonusMatch
+                    
+                    // Bonus for boundary
+                    if j == 1 || string[string.index(string.startIndex, offsetBy: j - 2)] == " " {
+                        score += ScoreConfig.bonusBoundary
+                    }
+                    
+                    // Bonus for consecutive matches
+                    if i > 1 && j > 1 && pattern[pattern.index(pattern.startIndex, offsetBy: i - 2)] == string[string.index(string.startIndex, offsetBy: j - 2)] {
+                        score += ScoreConfig.bonusConsecutive
+                    }
+                    
+                    let prevScore = scores[i - 1][j - 1]
+                    let newScore = prevScore + score
+                    
+                    // Check if we should extend previous match or start new one
+                    if newScore > scores[i - 1][j] + ScoreConfig.penaltyGapStart {
+                        scores[i][j] = newScore
+                        positions[i][j] = positions[i - 1][j - 1] + [j - 1]
+                    } else {
+                        scores[i][j] = scores[i - 1][j] + ScoreConfig.penaltyGapStart
+                        positions[i][j] = positions[i - 1][j]
+                    }
+                } else {
+                    // Penalty for gaps
+                    let gapScore = max(
+                        scores[i][j - 1] + ScoreConfig.penaltyGapExtension,
+                        scores[i - 1][j] + ScoreConfig.penaltyGapStart
+                    )
+                    scores[i][j] = gapScore
+                    positions[i][j] = positions[i][j - 1]
+                }
+            }
+        }
+        
+        // Check if we found a match
+        let finalScore = scores[patternLength][stringLength]
+        if finalScore > 0 {
+            return (true, FuzzyMatchResult(
+                string: string,
+                score: finalScore,
+                positions: positions[patternLength][stringLength]
+            ))
+        }
+        
+        return (false, nil)
+    }
+    
     // MARK: - Application Lifecycle
     
     /// Sets up the application window and UI components
@@ -486,12 +584,20 @@ class MenuApp: NSObject, NSApplicationDelegate, NSTableViewDataSource, NSTableVi
     /// - Parameter obj: The notification object
     func controlTextDidChange(_ obj: Notification) {
         guard let searchField = obj.object as? NSSearchField else { return }
-        let query = searchField.stringValue.lowercased()
+        let query = searchField.stringValue
         
         if query.isEmpty {
             filteredItems = allItems
         } else {
-            filteredItems = allItems.filter { $0.lowercased().contains(query) }
+            // Get matches with scores
+            let matches = allItems.compactMap { item -> FuzzyMatchResult? in
+                let (_, result) = fuzzyMatch(pattern: query, string: item)
+                return result
+            }
+            .sorted { $0.score > $1.score }
+            
+            // Extract just the strings in order of score
+            filteredItems = matches.map { $0.string }
         }
         
         tableView.reloadData()


### PR DESCRIPTION
<!-- Thank you for contributing to mac-menu! -->

### Description

<!-- Please describe your changes and why they are needed -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [X] Code refactoring
- [X] Performance improvement
- [ ] Other

### Changes

<!-- List the changes you made -->

- Replace simple substring search with fzf's Smith-Waterman algorithm
- Add sophisticated scoring system with bonuses for:
  - Character matches
  - Word boundaries
  - Consecutive matches
- Add penalties for gaps and non-contiguous matches
- Track match positions for potential future highlighting

### Testing

<!-- Describe how you tested your changes -->

- [X] Tested on macOS version:
- [X] Tested with different input types
- [X] Tested in pipe chains

### Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

### Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
